### PR TITLE
Applicative parsing post: `string_to_list` wasn't introduced

### DIFF
--- a/_posts/2019-05-19-applicative-parsing.md
+++ b/_posts/2019-05-19-applicative-parsing.md
@@ -183,7 +183,7 @@ let string s =
     (* Combine 'x' and 'xs' in a string *)
     Printf.sprintf "%c%s" x xs
   in
-  List.fold_right accum (string_to_list s) (return "")
+  List.fold_right accum (list_of_string s) (return "")
 ```
 
 Next, let's attempt a parser for parsing digits. A version that


### PR DESCRIPTION
Thoroughly enjoying reading the post - this is just fixing a small typo in the function being used that confused me at first because it hadn't been introduced.